### PR TITLE
Fix game start timer logic and reduce pre-game timer duration

### DIFF
--- a/public/typescript/handlers/starting-game/starting-game.handler.ts
+++ b/public/typescript/handlers/starting-game/starting-game.handler.ts
@@ -35,8 +35,11 @@ const startingGame = ({ secondsBefore, textId }: TimerBeforeStart) => {
     timer.innerText = secondsBefore.toString();
 
     void loadText(textId);
+    console.log(secondsBefore);
 
     if (!secondsBefore) {
+
+        console.log('startingGame');
         timer.className = 'display-none';
 
         const highlightedText = createElement({ tagName: 'span', className: 'highlight' });

--- a/public/typescript/handlers/starting-game/starting-game.handler.ts
+++ b/public/typescript/handlers/starting-game/starting-game.handler.ts
@@ -35,11 +35,9 @@ const startingGame = ({ secondsBefore, textId }: TimerBeforeStart) => {
     timer.innerText = secondsBefore.toString();
 
     void loadText(textId);
-    console.log(secondsBefore);
 
     if (!secondsBefore) {
 
-        console.log('startingGame');
         timer.className = 'display-none';
 
         const highlightedText = createElement({ tagName: 'span', className: 'highlight' });

--- a/public/typescript/views/game.ts
+++ b/public/typescript/views/game.ts
@@ -21,6 +21,6 @@ export const appendGameElement = ({ roomName, goBackToRooms, getReady }: AppendG
 
     timer.textContent = '';
 
-    quitRoomButton.addEventListener('click', goBackToRooms);
-    readyButton.addEventListener('click', getReady);
+    quitRoomButton.onclick = goBackToRooms;
+    readyButton.onclick = getReady;
 };

--- a/src/socket/config.ts
+++ b/src/socket/config.ts
@@ -1,3 +1,3 @@
 export const MAX_USERS_FOR_ROOM = 3;
-export const SECONDS_TIMER_BEFORE_START_GAME = 5;
-export const SECONDS_FOR_GAME = 120;
+export const SECONDS_TIMER_BEFORE_START_GAME = 3
+export const SECONDS_FOR_GAME = 120

--- a/src/socket/helpers/timer/timer.helper.ts
+++ b/src/socket/helpers/timer/timer.helper.ts
@@ -44,17 +44,13 @@ const timerLeft = ({ io, roomName, currentUser, roomUsers }: TimerLeft) => {
 };
 
 const timer = ({ currentUser, io, roomName, roomUsers, socket }: Timer) => {
-    const isReady = isRoomReady(roomUsers, roomName);
+    const textId = Math.floor(Math.random() * texts.length);
 
-    if (isReady) {
-        const textId = Math.floor(Math.random() * texts.length);
+    socket.broadcast.emit(Event.UPDATE_ROOMS, { roomsToRemove: [roomName] });
 
-        socket.broadcast.emit(Event.UPDATE_ROOMS, { roomsToRemove: [roomName] });
+    timerBeforeStart({ io, roomName, textId });
 
-        timerBeforeStart({ io, roomName, textId });
-
-        timerLeft({ currentUser, io, roomName, roomUsers });
-    }
+    timerLeft({ currentUser, io, roomName, roomUsers });
 };
 
 export { timer };

--- a/src/socket/socket.ts
+++ b/src/socket/socket.ts
@@ -60,7 +60,10 @@ export default (io: Server<ClientToServerEvents, ServerToClientEvents>) => {
 
             io.to(currentRoom).emit(Event.GOT_READY, ready, username);
 
-            timer({ currentUser, io, roomName: currentRoom, roomUsers, socket });
+            const roomIsReady = isRoomReady(roomUsers, currentRoom);
+            if (roomIsReady) {
+                timer({ currentUser, io, roomName: currentRoom, roomUsers, socket });
+            }
         });
 
         socket.on(Event.PROGRESSION, progress => {
@@ -81,7 +84,9 @@ export default (io: Server<ClientToServerEvents, ServerToClientEvents>) => {
 
             const rooms = roomsNotReady(roomUsers);
             const roomsToRemove = emptyRooms(roomUsers);
-            !roomUsers.get(currentRoom)?.size && roomUsers.delete(currentRoom);
+            if (!roomUsers.get(currentRoom)?.size) {
+                roomUsers.delete(currentRoom);
+            }
 
             socket.broadcast.emit(Event.UPDATE_ROOMS, { rooms, roomsToRemove });
             socket.to(currentRoom).emit(Event.LEAVE_ROOM, username);
@@ -90,7 +95,9 @@ export default (io: Server<ClientToServerEvents, ServerToClientEvents>) => {
         socket.on('disconnect', () => {
             usernames.delete(username);
             roomUsers.get(currentRoom)?.delete(currentUser);
-            !roomUsers.get(currentRoom)?.size && roomUsers.delete(currentRoom);
+            if (!roomUsers.get(currentRoom)?.size) {
+                roomUsers.delete(currentRoom);
+            }
 
             socket.to(currentRoom).emit(Event.LEAVE_ROOM, username);
         });


### PR DESCRIPTION
## Summary
- Adjust game start timer logic to ensure room readiness before countdown
- Reduce pre-game timer duration from 5 to 3 seconds
- Update event listener syntax for better compatibility
- Clean up conditional logic for room cleanup operations