### PR TITLE
Update ready button message to 'Waiting for others'

### DIFF
--- a/public/typescript/game.ts
+++ b/public/typescript/game.ts
@@ -44,7 +44,7 @@ socket.on(Event.JOIN_DONE, (roomName, usersJoined) => {
 socket.on(Event.GOT_READY, (ready, userName) => {
     if (userName === username) {
         const readyButton = <HTMLButtonElement>document.getElementById('ready-btn');
-        readyButton.innerText = 'Not Ready';
+        readyButton.innerText = 'Waiting for others';
     }
 
     changeReadyStatus({ ready, username: userName });


### PR DESCRIPTION
## Summary
- Changed the ready button message from "Not Ready" to "Waiting for others" after clicking the ready button
- This provides clearer feedback to users about the game state

## Changes
- Updated `public/typescript/game.ts:47` to change button text to "Waiting for others"